### PR TITLE
fix: Fix parsing logic for mark command

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ dependencies {
 }
 
 shadowJar {
-    archiveFileName = 'addressbook.jar'
+    archiveFileName = 'nerdTrackerPlus.jar'
 }
 
 defaultTasks 'clean', 'test'

--- a/src/main/java/seedu/address/logic/commands/MarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkCommand.java
@@ -54,8 +54,6 @@ public class MarkCommand extends Command {
         requireNonNull(model);
         List<Person> lastShownList = model.getFilteredPersonList();
 
-        System.out.println(targetIndex.getZeroBased());
-
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }

--- a/src/main/java/seedu/address/logic/commands/MarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkCommand.java
@@ -54,6 +54,8 @@ public class MarkCommand extends Command {
         requireNonNull(model);
         List<Person> lastShownList = model.getFilteredPersonList();
 
+        System.out.println(targetIndex.getZeroBased());
+
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }

--- a/src/main/java/seedu/address/logic/parser/MarkCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/MarkCommandParser.java
@@ -14,7 +14,7 @@ public class MarkCommandParser implements Parser<MarkCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of MarkCommand
      * and returns a MarkCommand object for execution.
-     * @throws ParseException if the user inout does not conform the expected format
+     * @throws ParseException if the user input does not conform the expected format
      */
     public MarkCommand parse(String args) throws ParseException {
         try {

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -8,6 +9,7 @@ import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
+import seedu.address.logic.commands.MarkCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
@@ -41,11 +43,17 @@ public class ParserUtil {
      * @throws ParseException if any of the specified index is invalid (not non-zero unsigned integer).
      */
     public static Index[] parseIndexes(String oneBasedIndexes) throws ParseException {
-        String trimmedIndexes = oneBasedIndexes.replaceAll("\\s+", "");
+        String[] indexArray = oneBasedIndexes.trim().split(" ");
         Index[] indexes = new Index[2];
 
-        String personIndex = trimmedIndexes.substring(0, 1);
-        String weekNumber = trimmedIndexes.substring(1, 3);
+        System.out.println(indexArray.length);
+        if (indexArray.length != 2) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkCommand.MESSAGE_USAGE));
+        }
+
+        String personIndex = indexArray[0];
+        String weekNumber = indexArray[1];
+
         if (!StringUtil.isNonZeroUnsignedInteger(personIndex) | !StringUtil.isNonZeroUnsignedInteger(weekNumber)) {
             throw new ParseException(MESSAGE_INVALID_INDEX);
         }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -46,7 +46,6 @@ public class ParserUtil {
         String[] indexArray = oneBasedIndexes.trim().split(" ");
         Index[] indexes = new Index[2];
 
-        System.out.println(indexArray.length);
         if (indexArray.length != 2) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkCommand.MESSAGE_USAGE));
         }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

-   [ ] Refactor
-   [ ] Feature
-   [ ] Bug Fix
-   [ ] Optimization
-   [ ] Documentation Update

## Description

-   Fix bug regarding the parsing logic for the mark command. Previously, parseIndexes used the .substring() method to split the arguments provided, which prevented valid double digit persons/weeks from being marked

## Related Tickets & Documents

-   Related Issue #57 

## Added/updated tests?

_We encourage you to keep the code coverage percentage at 75% and above for new changes._

-   [ ] Yes
-   [ ] No, and this is why: <_please replace this line with details on why tests
    have not been included_>
-   [ ] No, there are UI changes that I'm unable to cover.
-   [ ] I need help with writing tests

## [Optional] Are there any post deployment tasks we need to perform?
